### PR TITLE
fix: display empty title on empty combobox

### DIFF
--- a/resources/js/Components/Combobox.tsx
+++ b/resources/js/Components/Combobox.tsx
@@ -62,9 +62,11 @@ export default function Combobox({
 			<PopoverContent className="w-full p-0">
 				<Command>
 					<CommandInput placeholder={placeholder} />
+
 					<CommandEmpty>
 						{emptyTitle ?? "No hay resultados disponibles."}
 					</CommandEmpty>
+
 					<CommandGroup>
 						{options.map((option) => (
 							<CommandItem

--- a/resources/js/Components/ui/command.tsx
+++ b/resources/js/Components/ui/command.tsx
@@ -1,5 +1,5 @@
 import { DialogProps } from "@radix-ui/react-dialog";
-import { Command as CommandPrimitive } from "cmdk";
+import { Command as CommandPrimitive, useCommandState } from "cmdk";
 import { Search } from "lucide-react";
 import * as React from "react";
 
@@ -71,16 +71,43 @@ const CommandList = React.forwardRef<
 
 CommandList.displayName = CommandPrimitive.List.displayName;
 
+// const CommandEmpty = React.forwardRef<
+// 	React.ElementRef<typeof CommandPrimitive.Empty>,
+// 	React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
+// >((props, ref) => (
+
+// 	<CommandPrimitive.Empty
+// 		ref={ref}
+// 		className="py-6 text-center text-sm"
+// 		{...props}
+// 	/>
+// ));
+
+/**
+ * The current implementation doesn't display the command empty
+ * when there are no items to display.
+ *
+ * Therefore it was implemented the solution on the following issue
+ * {@link https://github.com/pacocoursey/cmdk/issues/149}.
+ */
 const CommandEmpty = React.forwardRef<
-	React.ElementRef<typeof CommandPrimitive.Empty>,
-	React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
->((props, ref) => (
-	<CommandPrimitive.Empty
-		ref={ref}
-		className="py-6 text-center text-sm"
-		{...props}
-	/>
-));
+	HTMLDivElement,
+	React.ComponentProps<typeof CommandPrimitive.Empty>
+>(({ className, ...props }, forwardedRef) => {
+	const render = useCommandState((state) => state.filtered.count === 0);
+
+	if (!render) return null;
+
+	return (
+		<div
+			ref={forwardedRef}
+			className={cn("py-6 text-center text-sm", className)}
+			cmdk-empty=""
+			role="presentation"
+			{...props}
+		/>
+	);
+});
 
 CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
 


### PR DESCRIPTION
The `Combobox` didn't display the empty title when there were no items to display on first render. 