### PR TITLE
fix: install ziggy as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
         "react-dom": "^18.2.0",
         "tailwindcss": "^3.3.3",
         "typescript": "^5.2.2",
-        "vite": "^4.5.0"
+        "vite": "^4.5.0",
+        "ziggy-js": "^1.8.1"
     },
     "dependencies": {
         "@fontsource-variable/dm-sans": "^5.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,9 @@ devDependencies:
   vite:
     specifier: ^4.5.0
     version: 4.5.0(@types/node@18.18.6)
+  ziggy-js:
+    specifier: ^1.8.1
+    version: 1.8.1
 
 packages:
 
@@ -3250,6 +3253,11 @@ packages:
       side-channel: 1.0.4
     dev: true
 
+  /qs@6.9.7:
+    resolution: {integrity: sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==}
+    engines: {node: '>=0.6'}
+    dev: true
+
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -3726,4 +3734,10 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: true
+
+  /ziggy-js@1.8.1:
+    resolution: {integrity: sha512-fnf30uG0yvUQBPL4T8YPgmkBHUdjYaOFgUb1K1gj0+rclnLTNr9/K/cxC3xkCZyYCZz8oTnXkdf3oJXRPSzavw==}
+    dependencies:
+      qs: 6.9.7
     dev: true

--- a/resources/js/ssr.tsx
+++ b/resources/js/ssr.tsx
@@ -18,6 +18,7 @@ createServer((page) =>
 				import.meta.glob("./Pages/**/*.tsx"),
 			),
 		setup: ({ App, props }) => {
+			// @ts-expect-error
 			global.route = (name, params, absolute) =>
 				route(name, params, absolute, {
 					// @ts-expect-error


### PR DESCRIPTION
Install [ziggy-js](https://www.npmjs.com/package/ziggy-js) as dependency to fix missing package errors.